### PR TITLE
Parser 0.1:

### DIFF
--- a/src/main/cup/parser.cup
+++ b/src/main/cup/parser.cup
@@ -4,36 +4,159 @@ import java_cup.runtime.*;
 
 class Parser;
 
+parser code {:
+    public boolean syntaxErrors;
 
-// Terminals
-terminal ASSIG;
-terminal PLUS;
-terminal SUB;
-terminal MULT;
-terminal DIV;
-terminal OPEN_BRACKET;
-terminal CLOSE_BRACKET;
-terminal INTEGER_CONSTANT;
-terminal IDENTIFIER;
+    public void syntax_error(Symbol current_token) {
+        report_error(
+            "Syntax error at line " + (current_token.left + 1) + 
+            ", column " + current_token.right + "\n", null
+        );
+    }
 
-// Non Terminals
-non terminal sentence;
-non terminal assignment;
-non terminal expression;
-non terminal term;
+    private void print(String str) {
+        System.out.println("Regla: " + str);
+    }
+:};
+
+// terminales
+terminal CTE;
+terminal ID;
+terminal STRING_LITERAL;
+
+terminal OP_ASIG;
+terminal OP_MAS;
+terminal OP_MENOS;
+terminal OP_MULT;
+terminal OP_DIV;
+terminal OP_AND;
+terminal OP_OR;
+terminal OP_NOT;
+
+terminal COMP_EQ;
+terminal COMP_DIST;
+terminal COMP_MAYOR;
+terminal COMP_MENOR;
+terminal COMP_MAYOR_EQ;
+terminal COMP_MENOR_EQ;
+
+terminal ABRE_LLAVE;
+terminal CIERRA_LLAVE;
+terminal ABRE_PAR;
+terminal CIERRA_PAR;
+terminal ABRE_LISTA;
+terminal CIERRA_LISTA;
+
+terminal COND_IF;
+terminal COND_ELSE;
+terminal CICLO;
+
+terminal TD_INT;
+terminal TD_FLOAT;
+terminal TD_STRING;
+
+terminal INIC_VARS;
+terminal COMA;
+terminal DOS_PUNTOS;
+terminal PUNTO_COMA;
+
+terminal LEER_TECLADO;
+terminal MOSTRAR_PANTALLA;
+terminal FUNC_INDICE;
+terminal FUNC_CONCAT;
+
+// Non terminales
+non terminal programa;
+non terminal sentencia;
+non terminal asignacion;
+non terminal iteracion;
+non terminal seleccion;
+non terminal expresion;
+non terminal condicion;
+non terminal comparacion;
+non terminal comparador;
+non terminal argumentos;
+non terminal termino;
 non terminal factor;
+non terminal fn_llamado;
+non terminal fn_nombre;
+non terminal declaracion;
+non terminal declaracion_lista;
+non terminal var_lista;
+non terminal var_tipo;
+non terminal lista;
+non terminal lista_rec;
 
 // Start Symbol Definition
-start with sentence;
+start with programa;
 
-sentence ::= assignment {: System.out.println("End"); :};
-assignment ::= IDENTIFIER ASSIG expression {: System.out.println("Assignment"); :};
-expression ::= expression PLUS term {: System.out.println("+"); :};
-expression ::= expression SUB term {: System.out.println("-"); :};
-expression ::= term {: System.out.println("Expression = Term"); :};
-term ::= term MULT factor {: System.out.println("*"); :};
-term ::= term DIV factor {: System.out.println("/"); :};
-term ::= factor {: System.out.println("Term = factor"); :};
-factor ::= IDENTIFIER:id  {: System.out.println("Id: " + id); :};
-factor ::= INTEGER_CONSTANT:constant {: System.out.println("Constant: " + constant ); :};
-factor ::= OPEN_BRACKET expression CLOSE_BRACKET {: System.out.println("Factor = (Expression)"); :};
+programa ::= sentencia {: print("programa ::= sentencia"); :};
+programa ::= programa sentencia {: print("programa ::= programa sentencia"); :};
+
+sentencia ::= asignacion PUNTO_COMA {: print("sentencia ::= asignacion;"); :};
+sentencia ::= fn_llamado PUNTO_COMA {: print("sentencia ::= fn_llamado;"); :};
+sentencia ::= declaracion PUNTO_COMA {: print("sentencia ::= declaracion;"); :};
+sentencia ::= iteracion {: print("sentencia ::= iteracion"); :};
+sentencia ::= seleccion {: print("sentencia ::= seleccion"); :};
+
+asignacion ::= ID OP_ASIG expresion {: print("asignacion ::= id = expresion"); :};
+
+iteracion ::= CICLO ABRE_PAR condicion CIERRA_PAR ABRE_LLAVE programa CIERRA_LLAVE {: print("iteracion ::= while(expresion) { programa }"); :};
+
+seleccion ::= COND_IF ABRE_PAR condicion CIERRA_PAR ABRE_LLAVE programa CIERRA_LLAVE {: print("seleccion ::= if(expresion) { programa }"); :};
+seleccion ::= COND_IF ABRE_PAR condicion CIERRA_PAR ABRE_LLAVE programa CIERRA_LLAVE COND_ELSE ABRE_LLAVE programa CIERRA_LLAVE {: print("seleccion ::= if(expresion) { programa } else { programa }"); :};
+
+condicion ::= comparacion {: print("condicion ::= comparacion"); :};
+condicion ::= OP_NOT comparacion {: print("condicion ::= not comparacion"); :};
+condicion ::= condicion OP_OR comparacion {: print("condicion ::= condicion or comparacion"); :};
+condicion ::= condicion OP_AND comparacion {: print("condicion ::= condicion and comparacion"); :};
+
+comparacion ::= expresion comparador expresion {: print("comparacion ::= expresion comparador expresion"); :};
+
+comparador ::= COMP_EQ  {: print("comparador ::= COMP_EQ"); :}
+             | COMP_DIST  {: print("comparador ::= COMP_DIST"); :}
+             | COMP_MAYOR  {: print("comparador ::= COMP_MAYOR"); :}
+             | COMP_MENOR  {: print("comparador ::= COMP_MENOR"); :}
+             | COMP_MAYOR_EQ  {: print("comparador ::= COMP_MAYOR_EQ"); :}
+             | COMP_MENOR_EQ  {: print("comparador ::= COMP_MENOR_EQ"); :};
+
+expresion ::= expresion OP_MAS termino {: print("expresion ::= expresion + termino"); :};
+expresion ::= expresion OP_MENOS termino {: print("expresion ::= expresion - termino"); :};
+expresion ::= termino {: print("expresion ::= termino"); :};
+
+termino ::= termino OP_MULT factor {: print("termino ::= termino * factor"); :};
+termino ::= termino OP_DIV factor {: print("termino ::= termino / factor"); :};
+termino ::= factor {: print("termino ::= factor"); :};
+
+factor ::= ID {: print("factor ::= ID"); :};
+factor ::= CTE {: print("factor ::= CTE"); :};
+factor ::= fn_llamado {: print("factor ::= fn_llamado"); :};
+factor ::= STRING_LITERAL {: print("factor ::= STRING_LITERAL"); :};
+factor ::= ABRE_PAR expresion CIERRA_PAR {: print("factor ::= (expresion)"); :};
+
+fn_llamado ::= fn_nombre ABRE_PAR argumentos CIERRA_PAR {: print("fn_llamado ::= fn_nombre(argumentos)"); :};
+
+fn_nombre ::= MOSTRAR_PANTALLA {: print("fn_nombre ::= MOSTRAR_PANTALLA"); :}
+            | LEER_TECLADO {: print("fn_nombre ::= LEER_TECLADO"); :}
+            | FUNC_INDICE {: print("fn_nombre ::= FUNC_INDICE"); :}
+            | FUNC_CONCAT {: print("fn_nombre ::= FUNC_CONCAT"); :};
+
+argumentos ::= factor {: print("argumentos ::= factor"); :};
+argumentos ::= argumentos COMA factor {: print("argumentos ::= factor, factor, ..."); :};
+argumentos ::= argumentos COMA lista {: print("argumentos ::= ..., [id, id, ...]"); :};
+
+declaracion ::= INIC_VARS ABRE_LLAVE declaracion_lista CIERRA_LLAVE {: print("declaracion ::= vars { declaracion_lista };"); :};
+
+declaracion_lista ::= var_lista DOS_PUNTOS var_tipo {: print("declaracion_lista ::= id, id, ... : var_tipo"); :};
+declaracion_lista ::= declaracion_lista COMA var_lista DOS_PUNTOS var_tipo {: print("declaracion_lista ::= id, id, ... : var_tipo,\n id, id, ... : var_tipo,\n ..."); :};
+
+var_lista ::= ID {: print("var_lista ::= id"); :};
+var_lista ::= var_lista COMA ID {: print("var_lista ::= id, id, ..."); :};
+
+var_tipo ::= TD_INT {: print("var_tipo ::= TD_INT"); :}
+           | TD_FLOAT {: print("var_tipo ::= TD_FLOAT"); :} 
+           | TD_STRING {: print("var_tipo ::= TD_STRING"); :};
+
+lista ::= ABRE_LISTA lista_rec CIERRA_LISTA {: print("lista ::= [factor, factor, ...]"); :};
+lista_rec ::= factor {: print("lista_rec ::= factor"); :};
+lista_rec ::= lista_rec COMA factor {: print("lista_rec ::= factor, factor, ..."); :};

--- a/src/main/java/lyc/compiler/constants/Constants.java
+++ b/src/main/java/lyc/compiler/constants/Constants.java
@@ -2,7 +2,9 @@ package lyc.compiler.constants;
 
 public final class Constants {
 
-    public static final int MAX_LENGTH = 30;
+    public static final int INT_MAX_LENGTH = 5;
+    public static final int FLOAT_MAX_LENGTH = 10;
+    public static final int STRING_MAX_LENGTH = 40;
 
     private Constants(){}
 

--- a/src/main/jflex/lexer.flex
+++ b/src/main/jflex/lexer.flex
@@ -4,7 +4,6 @@ import java_cup.runtime.Symbol;
 import lyc.compiler.ParserSym;
 import lyc.compiler.model.*;
 import static lyc.compiler.constants.Constants.*;
-import java.lang.System;
 
 %%
 
@@ -21,38 +20,45 @@ import java.lang.System;
 
 
 %{
-  private Symbol symbol(int type, String texto) {
-      System.out.println(texto);
+  private Symbol symbol(int type) {
       return new Symbol(type, yyline, yycolumn);
   }
+
+  private Symbol symbol(int type, String texto) {
+      //System.out.println("Token: " + texto);
+      return new Symbol(type, yyline, yycolumn);
+  }
+
   private Symbol symbol(int type, Object value) {
     return new Symbol(type, yyline, yycolumn, value);
   }
 %}
 
 
-LineTerminator = \r|\n|\r\n
-InputCharacter = [^\r\n]
-Identation =  [ \t\f]
-
 OP_MAS = "+"
 OP_MULT = "*"
 OP_MENOS = "-"
 OP_DIV = "/"
 OP_ASIG = "="
+
 OP_AND = "and"
 OP_OR = "or"
 OP_NOT = "not"
+
 COMP_EQ = "=="
 COMP_DIST = "!="
 COMP_MAYOR = ">"
 COMP_MENOR = "<"
 COMP_MAYOR_EQ = ">="
 COMP_MENOR_EQ = "<="
+
 ABRE_PAR = "("
 CIERRA_PAR = ")"
 ABRE_LLAVE = "{"
 CIERRA_LLAVE = "}"
+ABRE_LISTA = "["
+CIERRA_LISTA = "]"
+
 COND_IF = "if"
 COND_ELSE = "else"
 CICLO = "while"
@@ -60,42 +66,43 @@ TD_INT = "int"
 TD_FLOAT = "float"
 TD_STRING = "string"
 INIC_VARS = "vars"
-COMA = ","
-DOS_PUNTOS = ":"
-PUNTO_COMA = ";"
-ABRE_COM = "#/"
-CIERRA_COM = "\#"
 LEER_TECLADO = "read"
 MOSTRAR_PANTALLA = "write"
 FUNC_INDICE = "FirstIndexOf"
 FUNC_CONCAT = "ConcatenarConRecorte"
 
+COMA = ","
+DOS_PUNTOS = ":"
+PUNTO_COMA = ";"
+
+LineTerminator = \r|\n|\r\n
+InputCharacter = [^\r\n]
+Identation =  [ \t\f]
+
+MultilineComment = "#/" [^\\] ~"\#" | "#/" "\\"+ "#"
+EndOfLineComment = "//" {InputCharacter}* {LineTerminator}?
+Comment = {MultilineComment} | {EndOfLineComment}
 
 Letra = [a-zA-Z]
 Digito = [0-9]
 
 WhiteSpace = {LineTerminator} | {Identation}
-Identifier = {Letra} ({Letra}|{Digito})*
-IntegerConstant = {Digito}+
+ID = {Letra}({Letra}|{Digito})*
+StringLiteral = \"(.[^\"]*)\"
+Integer = [1-9][0-9]*
+Float = (\.)?{Integer}(\.[0-9]*)?
+
 
 %%
 
 
-/* keywords */
-
 <YYINITIAL> {
-  /* identifiers */
-  {Identifier}                             { return symbol(ParserSym.IDENTIFIER, yytext()); }
-  /* Constants */
-  {IntegerConstant}                        { return symbol(ParserSym.INTEGER_CONSTANT, yytext()); }
-
   /* operators */
-
-  {OP_MAS}                                 { return symbol(ParserSym.PLUS, "OP_MAS"); }
-  {OP_MENOS}                               { return symbol(ParserSym.SUB, "OP_MENOS"); }
-  {OP_MULT}                                { return symbol(ParserSym.MULT, "OP_MULT"); }
-  {OP_DIV}                                 { return symbol(ParserSym.DIV, "OP_DIV"); }
-  {OP_ASIG}                                { return symbol(ParserSym.ASSIG, "OP_ASIG"); }
+  {OP_MAS}                                 { return symbol(ParserSym.OP_MAS, "OP_MAS"); }
+  {OP_MENOS}                               { return symbol(ParserSym.OP_MENOS, "OP_MENOS"); }
+  {OP_MULT}                                { return symbol(ParserSym.OP_MULT, "OP_MULT"); }
+  {OP_DIV}                                 { return symbol(ParserSym.OP_DIV, "OP_DIV"); }
+  {OP_ASIG}                                { return symbol(ParserSym.OP_ASIG, "OP_ASIG"); }
   {OP_AND}                                 { return symbol(ParserSym.OP_AND, "OP_AND"); }
   {OP_OR}                                  { return symbol(ParserSym.OP_OR, "OP_OR"); }
   {OP_NOT}                                 { return symbol(ParserSym.OP_NOT, "OP_NOT"); }
@@ -111,6 +118,8 @@ IntegerConstant = {Digito}+
   {CIERRA_PAR}                             { return symbol(ParserSym.CIERRA_PAR, "CIERRA_PAR"); }
   {ABRE_LLAVE}                             { return symbol(ParserSym.ABRE_LLAVE, "ABRE_LLAVE"); }
   {CIERRA_LLAVE}                           { return symbol(ParserSym.CIERRA_LLAVE, "CIERRA_LLAVE"); }
+  {ABRE_LISTA}                             { return symbol(ParserSym.ABRE_LISTA, "ABRE_LISTA"); }
+  {CIERRA_LISTA}                           { return symbol(ParserSym.CIERRA_LISTA, "ABRE_LISTA"); }
 
   {COND_IF}                                { return symbol(ParserSym.COND_IF, "COND_IF"); }
   {COND_ELSE}                              { return symbol(ParserSym.COND_ELSE, "COND_ELSE"); }
@@ -124,18 +133,26 @@ IntegerConstant = {Digito}+
   {COMA}                                   { return symbol(ParserSym.COMA, "COMA"); }
   {DOS_PUNTOS}                             { return symbol(ParserSym.DOS_PUNTOS, "DOS_PUNTOS"); }
   {PUNTO_COMA}                             { return symbol(ParserSym.PUNTO_COMA, "PUNTO_COMA"); }
-  {ABRE_COM}                               { return symbol(ParserSym.ABRE_COM, "ABRE_COM"); }
-  {CIERRA_COM}                             { return symbol(ParserSym.CIERRA_COM, "CIERRA_COM"); }
+
   {LEER_TECLADO}                           { return symbol(ParserSym.LEER_TECLADO, "LEER_TECLADO"); }
   {MOSTRAR_PANTALLA}                       { return symbol(ParserSym.MOSTRAR_PANTALLA, "MOSTRAR_PANTALLA"); }
-  
   {FUNC_INDICE}                            { return symbol(ParserSym.FUNC_INDICE, "FUNC_INDICE"); }
   {FUNC_CONCAT}                            { return symbol(ParserSym.FUNC_CONCAT, "FUNC_CONCAT"); }
 
-  /* whitespace */
+
+  {ID}                                     { if (yylength() <= STRING_MAX_LENGTH) return symbol(ParserSym.ID, yytext()); 
+                                             else throw new InvalidLengthException("Longitud del identificador supera el tamaño maximo."); }
+  {Integer}                                { if (yylength() <= INT_MAX_LENGTH) return symbol(ParserSym.CTE, yytext()); 
+                                             else throw new InvalidLengthException("Supera el valor maximo de un numero int."); }
+  {Float}                                  { if (yylength() <= FLOAT_MAX_LENGTH) return symbol(ParserSym.CTE, yytext()); 
+                                             else throw new InvalidLengthException("Supera el valor maximo de un numero float."); }
+  {StringLiteral}                          { if (yylength() <= STRING_MAX_LENGTH) return symbol(ParserSym.STRING_LITERAL, yytext());
+                                             else throw new InvalidLengthException("String literal supera el tamaño maximo."); }
+
+
+  {Comment}                      { /* ignore */ }
   {WhiteSpace}                   { /* ignore */ }
 }
-
 
 /* error fallback */
 [^]                              { throw new UnknownCharacterException(yytext()); }

--- a/src/main/resources/input/test.txt
+++ b/src/main/resources/input/test.txt
@@ -1,1 +1,58 @@
-c=d*(e-21)/4
+#/ 
+    Creando
+    variables
+\#
+
+vars {
+    a, b : float,
+    i, MAX : int,
+    str1, str2 : string
+};
+
+#/ Asignaciones \#
+a = 3.;
+a = .1415;
+a = 3.14;
+b = a;
+MAX = 10;
+
+str1 = "@sdADa Sjfla%d  fg";
+str2 = read(str1);
+
+#/ Logica \#
+while (i < MAX) {
+    write("%d\n", i); #/ Funcion reservada \#
+
+    if (a - b > i) { #/ condicional if-else \#
+        c = d * (e-21) / 4;
+    }
+    else {
+        #/ loop dentro de un loop \#
+        vars { j : int };
+        j = MAX * #/ comentario en medio \# 2;
+
+        while (j > MAX and j - i < MAX) {
+            if (not b != a) {
+                i = i + 1;
+                j = j - 1;
+            }
+        }
+    }
+}
+
+b = FirstIndexOf(a, [1,b,2,5,z,C]);
+str1 = ConcatenarConRecorte("Hola", "Mundo", 2);
+
+#/ Errores \#
+
+#/ Compilation error: String literal supera el tamaño maximo. \#
+//str2 = "RVg1ceT8I42ttpmcg1WmcBPFW4ZevF X2fGdRgKuQc2OulDrkoY2E3Xe8BiAV";
+
+#/ Compilation error: Longitud del identificador supera el tamaño maximo. \#
+//p0jZaE1xBYfLzkNjfHoLV5StAkOzb9o2dWMEZ2qt3XxZ = 1;
+
+#/ Compilation error: Supera el valor maximo de un numero int. \#
+//MAX = 123456879;
+
+#/ Compilation error: Supera el valor maximo de un numero float. \#
+//a = 12345.123456789;

--- a/src/test/java/lyc/compiler/LexerTest.java
+++ b/src/test/java/lyc/compiler/LexerTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
-import static lyc.compiler.constants.Constants.MAX_LENGTH;
+import static lyc.compiler.constants.Constants.STRING_MAX_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
@@ -66,17 +66,17 @@ public class LexerTest {
   @Test
   public void assignmentWithExpressions() throws Exception {
     scan("c=d*(e-21)/4");
-    assertThat(nextToken()).isEqualTo(ParserSym.IDENTIFIER);
-    assertThat(nextToken()).isEqualTo(ParserSym.ASSIG);
-    assertThat(nextToken()).isEqualTo(ParserSym.IDENTIFIER);
-    assertThat(nextToken()).isEqualTo(ParserSym.MULT);
-    assertThat(nextToken()).isEqualTo(ParserSym.OPEN_BRACKET);
-    assertThat(nextToken()).isEqualTo(ParserSym.IDENTIFIER);
-    assertThat(nextToken()).isEqualTo(ParserSym.SUB);
-    assertThat(nextToken()).isEqualTo(ParserSym.INTEGER_CONSTANT);
-    assertThat(nextToken()).isEqualTo(ParserSym.CLOSE_BRACKET);
-    assertThat(nextToken()).isEqualTo(ParserSym.DIV);
-    assertThat(nextToken()).isEqualTo(ParserSym.INTEGER_CONSTANT);
+    assertThat(nextToken()).isEqualTo(ParserSym.ID);
+    assertThat(nextToken()).isEqualTo(ParserSym.OP_ASIG);
+    assertThat(nextToken()).isEqualTo(ParserSym.ID);
+    assertThat(nextToken()).isEqualTo(ParserSym.OP_MULT);
+    assertThat(nextToken()).isEqualTo(ParserSym.ABRE_LLAVE);
+    assertThat(nextToken()).isEqualTo(ParserSym.ID);
+    assertThat(nextToken()).isEqualTo(ParserSym.OP_MENOS);
+    assertThat(nextToken()).isEqualTo(ParserSym.CTE);
+    assertThat(nextToken()).isEqualTo(ParserSym.CIERRA_LLAVE);
+    assertThat(nextToken()).isEqualTo(ParserSym.OP_DIV);
+    assertThat(nextToken()).isEqualTo(ParserSym.CTE);
     assertThat(nextToken()).isEqualTo(ParserSym.EOF);
   }
 
@@ -105,7 +105,7 @@ public class LexerTest {
     return new RandomStringGenerator.Builder()
             .filteredBy(CharacterPredicates.LETTERS)
             .withinRange('a', 'z')
-            .build().generate(MAX_LENGTH * 2);
+            .build().generate(STRING_MAX_LENGTH * 2);
   }
 
 }


### PR DESCRIPTION
- Reglas semanticas con su respectivo output
- Casos de prueba necesarios
- Chequeo de cotas para identificadoes y constantes (int, float y string literals)
- Tokens para una lista '[' y ']'
- Arreglo en los tokens de comentario (ahora los ignora en lugar de pasarselos al parser)
- Comentarios tipo multilinea y fin de linea

Pagina de referencia: https://andreil26.github.io/me/uniprojects/2019/06/21/lexer_parser.html