### PR TITLE
Fix test in LexerTest and refactor Float and Integer regex in lexer.flex

### DIFF
--- a/src/main/jflex/lexer.flex
+++ b/src/main/jflex/lexer.flex
@@ -108,8 +108,8 @@ Digito = [0-9]
 WhiteSpace = {LineTerminator} | {Identation}
 ID = {Letra}({Letra}|{Digito})*
 StringLiteral = \"(.[^\"]*)\"
-Integer = [1-9][0-9]*
-Float = (\.)?{Integer}(\.[0-9]*)?
+Integer = [1-9]{Digito}*
+Float = \.{Digito}+ | {Digito}+\.{Digito}+ | {Integer}+\.
 
 
 %%

--- a/src/test/java/lyc/compiler/LexerTest.java
+++ b/src/test/java/lyc/compiler/LexerTest.java
@@ -65,7 +65,7 @@ public class LexerTest {
   @Test
   public void invalidPositiveFloatConstantValue() {
     assertThrows(InvalidFloatException.class, () -> {
-      scan("%f".formatted(92233720368.54775807999));
+      scan("92233720368.54775807999");
       nextToken();
     });
   }


### PR DESCRIPTION
Arreglé cómo se armaba el float para ser scanneado en uno de los tests de LexerTest, que no andaba en mi máquina.

También corregí la regex de float, que según entendí, por cómo estaba armada podía llegar a interpretar un 123.456.789 como float